### PR TITLE
reuse ledger clones

### DIFF
--- a/packages/node/src/stellar/api.stellar.ts
+++ b/packages/node/src/stellar/api.stellar.ts
@@ -211,8 +211,10 @@ export class StellarApi implements ApiWrapper<StellarBlockWrapper> {
         events,
       };
 
+      const clonedOp = cloneDeep(wrappedOp);
+
       effects.forEach((effect) => {
-        effect.operation = cloneDeep(wrappedOp);
+        effect.operation = clonedOp;
         wrappedOp.effects.push(effect);
       });
 
@@ -236,6 +238,7 @@ export class StellarApi implements ApiWrapper<StellarBlockWrapper> {
         events: [] as SorobanEvent[],
       };
 
+      const clonedTx = cloneDeep(wrappedTx);
       const operations = this.wrapOperationsForTx(
         tx.id,
         index + 1,
@@ -244,13 +247,13 @@ export class StellarApi implements ApiWrapper<StellarBlockWrapper> {
         effectsForSequence,
         eventsForSequence,
       ).map((op) => {
-        op.transaction = cloneDeep(wrappedTx);
+        op.transaction = clonedTx;
         op.effects = op.effects.map((effect) => {
-          effect.transaction = cloneDeep(wrappedTx);
+          effect.transaction = clonedTx;
           return effect;
         });
         op.events = op.events.map((event) => {
-          event.transaction = cloneDeep(wrappedTx);
+          event.transaction = clonedTx;
           return event;
         });
         return op;
@@ -316,16 +319,18 @@ export class StellarApi implements ApiWrapper<StellarBlockWrapper> {
       eventsForSequence,
     );
 
+    const clonedLedger = cloneDeep(wrappedLedger);
+
     wrapperTxs.forEach((tx) => {
-      tx.ledger = cloneDeep(wrappedLedger);
+      tx.ledger = clonedLedger;
       tx.operations = tx.operations.map((op) => {
-        op.ledger = cloneDeep(wrappedLedger);
+        op.ledger = clonedLedger;
         op.effects = op.effects.map((effect) => {
-          effect.ledger = cloneDeep(wrappedLedger);
+          effect.ledger = clonedLedger;
           return effect;
         });
         op.events = op.events.map((event) => {
-          event.ledger = cloneDeep(wrappedLedger);
+          event.ledger = clonedLedger;
           return event;
         });
         return op;


### PR DESCRIPTION
# Description
Too many `cloneDeep` operations are hurting the indexing performance. clone ledgers once and reuse them. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
