### PR TITLE
Performance issue caused by making too many RPC requests

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--network-endpoint-config` add optional parameter `limit`
+
+### Fixed
+- Performance issue caused by making too many RPC requests.
+
 ## [4.4.0] - 2025-02-05
 ### Changed
 - Update stellar sdk to v13 (#101)

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `--network-endpoint-config` add optional parameter `limit`
+- `--network-endpoint-config` add optional parameter `pageLimit`
 
 ### Fixed
 - Performance issue caused by making too many RPC requests.

--- a/packages/node/src/stellar/api.stellar.ts
+++ b/packages/node/src/stellar/api.stellar.ts
@@ -19,7 +19,7 @@ import { StellarBlockWrapped } from '../stellar/block.stellar';
 import SafeStellarProvider from './safe-api';
 import { SorobanServer } from './soroban.server';
 import { StellarServer } from './stellar.server';
-import { formatBlockUtil } from './utils.stellar';
+import { DEFAULT_PAGE_SIZE, formatBlockUtil } from './utils.stellar';
 
 const logger = getLogger('api.Stellar');
 
@@ -28,7 +28,7 @@ export class StellarApi implements ApiWrapper {
   private stellarClient: StellarServer;
 
   private chainId?: string;
-  private pageLimit = 150;
+  private pageLimit = DEFAULT_PAGE_SIZE;
 
   constructor(
     private endpoint: string,

--- a/packages/node/src/stellar/api.stellar.ts
+++ b/packages/node/src/stellar/api.stellar.ts
@@ -28,6 +28,7 @@ export class StellarApi implements ApiWrapper {
   private stellarClient: StellarServer;
 
   private chainId?: string;
+  private defaultLimit = 100;
 
   constructor(
     private endpoint: string,
@@ -35,6 +36,7 @@ export class StellarApi implements ApiWrapper {
     config?: IStellarEndpointConfig,
   ) {
     const { hostname, protocol, searchParams } = new URL(this.endpoint);
+    this.defaultLimit = config?.limit || this.defaultLimit;
 
     const protocolStr = protocol.replace(':', '');
 
@@ -100,7 +102,11 @@ export class StellarApi implements ApiWrapper {
     sequence: number,
   ): Promise<Horizon.ServerApi.TransactionRecord[]> {
     const txs: Horizon.ServerApi.TransactionRecord[] = [];
-    let txsPage = await this.api.transactions().forLedger(sequence).call();
+    let txsPage = await this.api
+      .transactions()
+      .forLedger(sequence)
+      .limit(this.defaultLimit)
+      .call();
     while (txsPage.records.length !== 0) {
       txs.push(...txsPage.records);
       txsPage = await txsPage.next();
@@ -113,7 +119,11 @@ export class StellarApi implements ApiWrapper {
     sequence: number,
   ): Promise<Horizon.ServerApi.OperationRecord[]> {
     const operations: Horizon.ServerApi.OperationRecord[] = [];
-    let operationsPage = await this.api.operations().forLedger(sequence).call();
+    let operationsPage = await this.api
+      .operations()
+      .forLedger(sequence)
+      .limit(this.defaultLimit)
+      .call();
     while (operationsPage.records.length !== 0) {
       operations.push(...operationsPage.records);
       operationsPage = await operationsPage.next();
@@ -126,7 +136,11 @@ export class StellarApi implements ApiWrapper {
     sequence: number,
   ): Promise<Horizon.ServerApi.EffectRecord[]> {
     const effects: Horizon.ServerApi.EffectRecord[] = [];
-    let effectsPage = await this.api.effects().forLedger(sequence).call();
+    let effectsPage = await this.api
+      .effects()
+      .forLedger(sequence)
+      .limit(this.defaultLimit)
+      .call();
     while (effectsPage.records.length !== 0) {
       effects.push(...effectsPage.records);
       effectsPage = await effectsPage.next();

--- a/packages/node/src/stellar/api.stellar.ts
+++ b/packages/node/src/stellar/api.stellar.ts
@@ -28,7 +28,7 @@ export class StellarApi implements ApiWrapper {
   private stellarClient: StellarServer;
 
   private chainId?: string;
-  private defaultLimit = 100;
+  private pageLimit = 150;
 
   constructor(
     private endpoint: string,
@@ -36,11 +36,13 @@ export class StellarApi implements ApiWrapper {
     config?: IStellarEndpointConfig,
   ) {
     const { hostname, protocol, searchParams } = new URL(this.endpoint);
-    this.defaultLimit = config?.limit || this.defaultLimit;
+    this.pageLimit = config?.pageLimit || this.pageLimit;
 
     const protocolStr = protocol.replace(':', '');
 
-    logger.info(`Api host: ${hostname}, method: ${protocolStr}`);
+    logger.info(
+      `Api host: ${hostname}, method: ${protocolStr}, pageLimit: ${this.pageLimit}`,
+    );
     if (protocolStr === 'https' || protocolStr === 'http') {
       const options: Horizon.Server.Options = {
         allowHttp: protocolStr === 'http',
@@ -105,7 +107,7 @@ export class StellarApi implements ApiWrapper {
     let txsPage = await this.api
       .transactions()
       .forLedger(sequence)
-      .limit(this.defaultLimit)
+      .limit(this.pageLimit)
       .call();
     while (txsPage.records.length !== 0) {
       txs.push(...txsPage.records);
@@ -122,7 +124,7 @@ export class StellarApi implements ApiWrapper {
     let operationsPage = await this.api
       .operations()
       .forLedger(sequence)
-      .limit(this.defaultLimit)
+      .limit(this.pageLimit)
       .call();
     while (operationsPage.records.length !== 0) {
       operations.push(...operationsPage.records);
@@ -139,7 +141,7 @@ export class StellarApi implements ApiWrapper {
     let effectsPage = await this.api
       .effects()
       .forLedger(sequence)
-      .limit(this.defaultLimit)
+      .limit(this.pageLimit)
       .call();
     while (effectsPage.records.length !== 0) {
       effects.push(...effectsPage.records);
@@ -166,6 +168,7 @@ export class StellarApi implements ApiWrapper {
     const { events: events } = await this.sorobanClient.getEvents({
       startLedger: height,
       filters: [],
+      limit: this.pageLimit,
     });
     return events.map((event) => {
       const wrappedEvent = {

--- a/packages/node/src/stellar/soroban.server.ts
+++ b/packages/node/src/stellar/soroban.server.ts
@@ -23,6 +23,7 @@ export class SorobanServer extends rpc.Server {
     events: CachedEventsResponse;
     eventsToCache: CachedEventsResponse;
   }> {
+    const pageLimit = request.limit ?? DEFAULT_PAGE_SIZE;
     const response = await super.getEvents(request);
 
     // Separate the events for the current sequence and the subsequent sequences
@@ -36,7 +37,7 @@ export class SorobanServer extends rpc.Server {
     const newEvents = accEvents.concat(events);
 
     if (eventsToCache?.length) {
-      if (response.events.length === DEFAULT_PAGE_SIZE) {
+      if (response.events.length === pageLimit) {
         const lastSequence = last(response.events)!.ledger;
         eventsToCache = eventsToCache.filter(
           (event) => event.ledger !== lastSequence,
@@ -51,7 +52,7 @@ export class SorobanServer extends rpc.Server {
       };
     }
 
-    if (response.events.length < DEFAULT_PAGE_SIZE) {
+    if (response.events.length < pageLimit) {
       return {
         events: { events: newEvents, latestLedger: response.latestLedger },
         eventsToCache: { events: [], latestLedger: response.latestLedger },

--- a/packages/node/src/stellar/soroban.server.ts
+++ b/packages/node/src/stellar/soroban.server.ts
@@ -4,8 +4,7 @@
 import { rpc } from '@stellar/stellar-sdk';
 import { SorobanRpcEventResponse } from '@subql/types-stellar';
 import { compact, groupBy, last } from 'lodash';
-
-const DEFAULT_PAGE_SIZE = 100;
+import { DEFAULT_PAGE_SIZE } from './utils.stellar';
 
 type CachedEventsResponse = Pick<
   rpc.Api.GetEventsResponse,

--- a/packages/node/src/stellar/utils.stellar.ts
+++ b/packages/node/src/stellar/utils.stellar.ts
@@ -31,3 +31,5 @@ export function formatBlockUtil<
 export function calcInterval(api: ApiWrapper): number {
   return 6000;
 }
+
+export const DEFAULT_PAGE_SIZE = 150;

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Performance issue caused by making too many RPC requests.
+- IStellarEndpointConfig add optional parameter `pageLimit`
 
 ## [4.1.0] - 2025-02-05
 ### Changed

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Performance issue caused by making too many RPC requests.
+
 ## [4.1.0] - 2025-02-05
 ### Changed
 - Update stellar sdk to v13 and use type from the sdk rather than redefining (#101)

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -321,9 +321,9 @@ export interface IStellarEndpointConfig extends IEndpointConfig {
   batchSize?: number;
 
   /**
-   * The default limit for the number of records to fetch
+   * The page limit for the number of records to fetch per request. Default value is 150
    */
-  limit?: number;
+  pageLimit?: number;
 }
 
 /**

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -319,6 +319,11 @@ export interface IStellarEndpointConfig extends IEndpointConfig {
    *  The JSON RPC batch size, if this is set to 0 it will not use batch requests
    * */
   batchSize?: number;
+
+  /**
+   * The default limit for the number of records to fetch
+   */
+  limit?: number;
 }
 
 /**


### PR DESCRIPTION
# Description
Currently, the default pagination limit for RPC is 10, which causes multiple IO operations. Increase the default limit to 100, and add the optional limit field in the `--network-endpoint-config` parameter.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
