### PR TITLE
handle http protocol option for soroban endpoint

### DIFF
--- a/packages/node/src/stellar/api.service.stellar.spec.ts
+++ b/packages/node/src/stellar/api.service.stellar.spec.ts
@@ -76,6 +76,12 @@ describe('StellarApiService', () => {
     [apiService, app] = await prepareApiService();
   });
 
+  it('should allow http protocol for soroban endpoint', async () => {
+    await expect(
+      prepareApiService(HTTP_ENDPOINT, 'http://rpc-futurenet.stellar.org'),
+    ).resolves.not.toThrow();
+  });
+
   it('should instantiate api', () => {
     expect(apiService.api).toBeInstanceOf(StellarApi);
   });

--- a/packages/node/src/stellar/api.service.stellar.ts
+++ b/packages/node/src/stellar/api.service.stellar.ts
@@ -80,8 +80,13 @@ export class StellarApiService extends ApiService<
       );
     }
 
+    const { protocol } = new URL(sorobanEndpoint);
+    const protocolStr = protocol.replace(':', '');
+
     const sorobanClient = sorobanEndpoint
-      ? new SorobanServer(sorobanEndpoint)
+      ? new SorobanServer(sorobanEndpoint, {
+          allowHttp: protocolStr === 'http',
+        })
       : undefined;
 
     await this.createConnections(network, (endpoint, config) =>


### PR DESCRIPTION
# Description
When developing locally, you're most likely using the [stellar/quickstart](https://github.com/stellar/quickstart) container meaning you work with http protocol.
The soroban client instanciation isn't allowing the http protocol.
This fix is doing the same thing than it's done for horizon which it's parsing the protocol to pass the option `allowHttp` if needed

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
