### PR TITLE
Sandbox API changes

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `@subql/node-core` (#124)
+
+### Added
+- Sandbox now has access to Horizon and Soroban Server APIs via `unsafeApi` and `unsafeSorobanApi` (#124)
 
 ## [5.0.2] - 2025-05-01
 ### Changed

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
     "@stellar/stellar-sdk": "^13.1.0",
     "@subql/common": "^5.6.0",
     "@subql/common-stellar": "workspace:*",
-    "@subql/node-core": "^18.0.4",
+    "@subql/node-core": "^18.1.0",
     "@subql/testing": "^2.2.0",
     "@subql/types-stellar": "workspace:*",
     "lodash": "^4.17.21",

--- a/packages/node/src/blockchain.service.ts
+++ b/packages/node/src/blockchain.service.ts
@@ -86,7 +86,7 @@ export class BlockchainService
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async getChainInterval(): Promise<number> {
-    const CHAIN_INTERVAL = calcInterval(this.apiService.api) * INTERVAL_PERCENT;
+    const CHAIN_INTERVAL = calcInterval() * INTERVAL_PERCENT;
 
     return Math.min(BLOCK_TIME_VARIANCE, CHAIN_INTERVAL);
   }

--- a/packages/node/src/stellar/api.stellar.ts
+++ b/packages/node/src/stellar/api.stellar.ts
@@ -5,7 +5,6 @@ import assert from 'assert';
 import { Horizon } from '@stellar/stellar-sdk';
 import { getLogger, IBlock } from '@subql/node-core';
 import {
-  ApiWrapper,
   SorobanEvent,
   StellarBlock,
   StellarBlockWrapper,
@@ -23,8 +22,7 @@ import { DEFAULT_PAGE_SIZE, formatBlockUtil } from './utils.stellar';
 
 const logger = getLogger('api.Stellar');
 
-export class StellarApi implements ApiWrapper {
-  //private client: Server;
+export class StellarApi {
   private stellarClient: StellarServer;
 
   private chainId?: string;

--- a/packages/node/src/stellar/utils.stellar.ts
+++ b/packages/node/src/stellar/utils.stellar.ts
@@ -3,11 +3,7 @@
 
 import { Horizon } from '@stellar/stellar-sdk';
 import { Header, IBlock } from '@subql/node-core';
-import {
-  ApiWrapper,
-  StellarBlock,
-  StellarBlockWrapper,
-} from '@subql/types-stellar';
+import { StellarBlock, StellarBlockWrapper } from '@subql/types-stellar';
 
 export function stellarBlockToHeader(
   block: StellarBlock | Horizon.ServerApi.LedgerRecord,
@@ -33,7 +29,7 @@ export function formatBlockUtil<
   };
 }
 
-export function calcInterval(api: ApiWrapper): number {
+export function calcInterval(): number {
   return 6000;
 }
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Redundant APIWrapper interface (#124)
+
+### Changed
+- Global injected apis (#124)
 
 ## [4.4.0] - 2025-04-24
 ### Changed

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -1,9 +1,17 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
-import {rpc} from '@stellar/stellar-sdk';
+import {Horizon, rpc} from '@stellar/stellar-sdk';
 import '@subql/types-core/dist/global';
 
 declare global {
-  const api: rpc.Server;
+  // const api: rpc.Server;
+
+  /*
+   * The unsafeApi allows direct acces to making RPC calls.
+   * WARNING: It is not scoped to the current block so it will query current chain state. This can lead to a project being non-deterministic.
+   * To have access to the unsafeApi please use the `unsafe` flag in your project configuration.
+   */
+  const unsafeApi: Horizon.Server | undefined;
+  const unsafeSorobanApi: rpc.Server | undefined;
 }

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -17,15 +17,4 @@ export interface BlockWrapper<
   events?: E[];
 }
 
-export interface ApiWrapper {
-  init: () => Promise<void>;
-  getGenesisHash: () => string;
-  getRuntimeChain: () => string;
-  getChainId: () => string;
-  getSpecName: () => string;
-  getFinalizedBlockHeight: () => Promise<number>;
-  getBestBlockHeight: () => Promise<number>;
-  //getBlockByHeightOrHash: (hashOrHeight: number | string) => Promise<Block>;
-}
-
 export type DynamicDatasourceCreator = (name: string, args: Record<string, unknown>) => Promise<void>;

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -1,6 +1,7 @@
 // Copyright 2020-2025 SubQuery Pte Ltd authors & contributors
 // SPDX-License-Identifier: GPL-3.0
 
+import {Horizon} from '@stellar/stellar-sdk';
 import {
   BaseTemplateDataSource,
   IProjectNetworkConfig,
@@ -17,7 +18,6 @@ import {
   BaseCustomDataSource,
   IEndpointConfig,
 } from '@subql/types-core';
-import {ApiWrapper} from './interfaces';
 import {
   StellarBlock,
   StellarBlockFilter,
@@ -289,8 +289,24 @@ export type SecondLayerHandlerProcessor<
   E,
   DS extends SubqlCustomDatasource = SubqlCustomDatasource
 > =
-  | SecondLayerHandlerProcessor_0_0_0<K, StellarRuntimeHandlerInputMap, StellarRuntimeFilterMap, F, E, DS, ApiWrapper>
-  | SecondLayerHandlerProcessor_1_0_0<K, StellarRuntimeHandlerInputMap, StellarRuntimeFilterMap, F, E, DS, ApiWrapper>;
+  | SecondLayerHandlerProcessor_0_0_0<
+      K,
+      StellarRuntimeHandlerInputMap,
+      StellarRuntimeFilterMap,
+      F,
+      E,
+      DS,
+      Horizon.Server
+    >
+  | SecondLayerHandlerProcessor_1_0_0<
+      K,
+      StellarRuntimeHandlerInputMap,
+      StellarRuntimeFilterMap,
+      F,
+      E,
+      DS,
+      Horizon.Server
+    >;
 export type SecondLayerHandlerProcessorArray<
   K extends string,
   F extends Record<string, unknown>,
@@ -312,7 +328,7 @@ export type SubqlDatasourceProcessor<
     string,
     SecondLayerHandlerProcessorArray<K, F, any, DS>
   >
-> = DsProcessor<DS, P, ApiWrapper>;
+> = DsProcessor<DS, P, Horizon.Server>;
 
 export interface IStellarEndpointConfig extends IEndpointConfig {
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2749,9 +2749,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/node-core@npm:^18.0.4":
-  version: 18.0.4
-  resolution: "@subql/node-core@npm:18.0.4"
+"@subql/node-core@npm:^18.1.0":
+  version: 18.1.0
+  resolution: "@subql/node-core@npm:18.1.0"
   dependencies:
     "@apollo/client": ^3.11.2
     "@nestjs/common": ^11.0.16
@@ -2760,7 +2760,7 @@ __metadata:
     "@subql/common": 5.6.0
     "@subql/testing": 2.2.4
     "@subql/types": 3.12.2
-    "@subql/utils": 2.18.1
+    "@subql/utils": 2.19.0
     "@willsoto/nestjs-prometheus": ^6.0.2
     async-mutex: ^0.5.0
     cron-converter: ^2.0.1
@@ -2777,7 +2777,7 @@ __metadata:
     toposort-class: ^1.0.1
     vm2: ^3.9.19
     yargs: ^16.2.0
-  checksum: 484574ba436fc984c8fda83e6904246636cd3c0eb92ea77201b9823dcce35a531cb70eaf239546679b1a2ac2d43231d3bce16c26500e5804142921b9417e0a2d
+  checksum: adfb16ccb3da46c74605dfb335bcb65c5914bc3ff68ca68b43e22b135f6a2717eeefa8348b8e32cb76dee12d6b8c43f39bcbb80b9027152529986545b2b5b4ee
   languageName: node
   linkType: hard
 
@@ -2795,7 +2795,7 @@ __metadata:
     "@stellar/stellar-sdk": ^13.1.0
     "@subql/common": ^5.6.0
     "@subql/common-stellar": "workspace:*"
-    "@subql/node-core": ^18.0.4
+    "@subql/node-core": ^18.1.0
     "@subql/testing": ^2.2.0
     "@subql/types-stellar": "workspace:*"
     "@types/express": ^4.17.13
@@ -2869,9 +2869,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@subql/utils@npm:2.18.1":
-  version: 2.18.1
-  resolution: "@subql/utils@npm:2.18.1"
+"@subql/utils@npm:2.19.0":
+  version: 2.19.0
+  resolution: "@subql/utils@npm:2.19.0"
   dependencies:
     "@polkadot/util": ^13.4.4
     "@polkadot/util-crypto": ^13.4.4
@@ -2884,7 +2884,7 @@ __metadata:
     lodash: ^4.17.21
     pino: ^6.13.3
     rotating-file-stream: ^3.2.3
-  checksum: cc680225def170d0b7cbccc757ab31cc4ef1fefff2793e6c544a79ffd4746b97713409e19b19d2cf85e9fb660aa8e12c5c4cd486b8e24470c252dc52899c4d17
+  checksum: b37fb552fcebe649d898441444c112d511095a0ff16e40a739700b684e66c33b0b0355ea41d6666fbaf1f722a63d34065cd5a61a5a559cbe609dfb5a36ea76ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
* Updates node core
* Removes API from the sandbox, the previously provided version offered no useful methods and was not actually the API
* Adds in `unsafeApi` and `unsafeSorobanApi` to expose the stellar sdk apis

Fixes https://github.com/subquery/subql-stellar/issues/123

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
