### PR TITLE
Fix: Remove assertion in wrapOperationsForTx for multi-operation events (fixes #131)

### DIFF
--- a/packages/node/src/stellar/api.stellar.ts
+++ b/packages/node/src/stellar/api.stellar.ts
@@ -182,13 +182,6 @@ export class StellarApi {
     effectsForSequence: Record<string, Horizon.ServerApi.EffectRecord[]>,
     events: SorobanEvent[],
   ): StellarOperation[] {
-    // If there are soroban events then there should only be a single operation.
-    // This check is here in case there are furture changes to the network.
-    assert(
-      events.length > 0 ? operations.length === 1 : true,
-      'Unable to assign events to multiple operations',
-    );
-
     return operations.map((op, index) => {
       const effects = (effectsForSequence[op.id] ?? []).map(
         this.wrapEffect.bind(this),


### PR DESCRIPTION
## Description
This PR removes the assertion in `wrapOperationsForTx` that was preventing transactions with multiple operations that emit events from being indexed properly.

## Changes
- Removed the assertion that was causing issues when transactions have multiple operations but still emit events

## Related Issues
Fixes #131

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
