### PR TITLE
Support mapping events for transactions with multiple operations

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Handle transactions with multiple operations and events correctly (#133)
 
 ## [6.0.1] - 2025-07-01
 ### Changed


### PR DESCRIPTION
# Description
Up until now, we had not come across a case where a transaction had multiple operations and events emitted. There was an assertion so we would catch this case. Now that we have found a transaction we can correctly handle it.

We now also map the events to the operations correctly using the operationIndex that is not exposed via typescript types but exists on the object

Fixes https://github.com/subquery/subql-stellar/issues/131

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
