### PR TITLE
Update stellar sdk, fix event cursors

### DIFF
--- a/packages/common-stellar/CHANGELOG.md
+++ b/packages/common-stellar/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update Stellar SDK to support protocol 23 (#135)
+- Update Stellar SDK to v14 with support for protocol 23 (#138)
 
 ## [4.4.3] - 2025-07-01
 ### Changed

--- a/packages/common-stellar/package.json
+++ b/packages/common-stellar/package.json
@@ -14,7 +14,7 @@
   "main": "dist/index.js",
   "license": "GPL-3.0",
   "dependencies": {
-    "@stellar/stellar-sdk": "14.0.0-rc.3",
+    "@stellar/stellar-sdk": "^14.1.0",
     "@subql/common": "^5.7.0",
     "@subql/types-stellar": "workspace:*",
     "js-yaml": "^4.1.0",

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update Stellar SDK to support protocol 23 (#135)
+- Update Stellar SDK to v14 with support for protocol 23 (#138)
+
+### Fixed
+- Pagination for getting events which used the deprecated pagingToken, it now uses the cursor (#138)
 
 ## [6.0.2] - 2025-07-21
 ### Fixed

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -24,7 +24,7 @@
     "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/platform-express": "^11.0.11",
     "@nestjs/schedule": "^5.0.1",
-    "@stellar/stellar-sdk": "14.0.0-rc.3",
+    "@stellar/stellar-sdk": "^14.1.0",
     "@subql/common": "^5.7.0",
     "@subql/common-stellar": "workspace:*",
     "@subql/node-core": "^18.2.0",

--- a/packages/node/src/stellar/soroban.server.spec.ts
+++ b/packages/node/src/stellar/soroban.server.spec.ts
@@ -53,16 +53,16 @@ describe('SorobanServer', () => {
 
   test('should handle response length less than DEFAULT_PAGE_SIZE', async () => {
     spy.mockResolvedValue({
-      events: Array.from({ length: DEFAULT_PAGE_SIZE - 1 }, (_, i) => ({
+      events: Array.from({ length: DEFAULT_PAGE_SIZE }, (_, i) => ({
         id: `${i}`,
-        ledger: 1,
-        pagingToken: `${i}`,
+        ledger: i < DEFAULT_PAGE_SIZE - 1 ? 1 : 2,
       })),
     });
 
     const response = await server.getEvents({
       startLedger: 1,
-    } as rpc.Server.GetEventsRequest);
+      filters: [],
+    });
 
     expect(response.events.length).toBe(DEFAULT_PAGE_SIZE - 1);
     expect(spy).toHaveBeenCalledTimes(1);
@@ -103,14 +103,12 @@ describe('SorobanServer', () => {
         events: Array.from({ length: DEFAULT_PAGE_SIZE }, (_, i) => ({
           id: `${i}`,
           ledger: 1,
-          pagingToken: `${i}`,
         })),
       })
       .mockResolvedValueOnce({
-        events: Array.from({ length: 5 }, (_, i) => ({
+        events: Array.from({ length: DEFAULT_PAGE_SIZE }, (_, i) => ({
           id: `${i + DEFAULT_PAGE_SIZE}`,
-          ledger: 1,
-          pagingToken: `${i + DEFAULT_PAGE_SIZE}`,
+          ledger: i < 5 ? 1 : 2,
         })),
       });
 
@@ -155,7 +153,7 @@ describe('SorobanServer', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
-  it('does pagination correctly', async () => {
+  it.skip('does pagination correctly', async () => {
     const legerNum = 58627181;
     server = new SorobanServer('https://stellar.api.onfinality.io/public/rpc');
     const spy = jest.spyOn(server as any, 'fetchEventsForSequence');

--- a/packages/node/src/stellar/soroban.server.spec.ts
+++ b/packages/node/src/stellar/soroban.server.spec.ts
@@ -154,4 +154,20 @@ describe('SorobanServer', () => {
     expect((server as any).eventsCache[2]).toBeUndefined();
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('does pagination correctly', async () => {
+    const legerNum = 58627181;
+    server = new SorobanServer('https://stellar.api.onfinality.io/public/rpc');
+    const spy = jest.spyOn(server as any, 'fetchEventsForSequence');
+    const events = await server.getEvents({
+      startLedger: legerNum,
+      filters: [],
+    });
+
+    expect(events).toBeDefined();
+    expect(events.events.every((evt) => evt.ledger === legerNum)).toBeTruthy();
+    expect(events.events.length).toEqual(160);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/node/src/stellar/soroban.server.ts
+++ b/packages/node/src/stellar/soroban.server.ts
@@ -53,6 +53,12 @@ export class SorobanServer extends rpc.Server {
       };
     }
     // We cannot check response.events.length < pageLimit here because the server may have a pageLimit below ours that it will use.
+    if (response.events.length === 0) {
+      return {
+        events: { events: newEvents, latestLedger: response.latestLedger },
+        eventsToCache: { events: [], latestLedger: response.latestLedger },
+      };
+    }
 
     // Prepare the next request
     const nextRequest = {

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Update Stellar SDK to support protocol 23 (#135)
+- Update Stellar SDK to v14 with support for protocol 23 (#138)
 
 ## [5.0.1] - 2025-07-01
 ### Changed

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -17,7 +17,7 @@
     "/dist"
   ],
   "dependencies": {
-    "@stellar/stellar-sdk": "14.0.0-rc.3",
+    "@stellar/stellar-sdk": "^14.1.0",
     "@subql/types-core": "^2.1.0"
   },
   "stableVersion": "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2245,12 +2245,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:^1.9.2":
-  version: 1.9.4
-  resolution: "@noble/curves@npm:1.9.4"
+"@noble/curves@npm:^1.9.6":
+  version: 1.9.7
+  resolution: "@noble/curves@npm:1.9.7"
   dependencies:
     "@noble/hashes": 1.8.0
-  checksum: 464813a81982ad670d2ae38452eea389066cf3b8d976ec2992dfa7c47b809a3703e7cf4f0915c559792fff97284563176e2ac5d06c353434292789404cbfc3dd
+  checksum: 65acad44ac6944ab96471109087d6cfcbcaa251faad6295961be9a5ace220634f4b7c74a96d1ee2274ad3880ea953d8e8259893ed8c906c831ef29f5c04ec9cc
   languageName: node
   linkType: hard
 
@@ -2663,25 +2663,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stellar/stellar-base@npm:^14.0.0-rc.2":
-  version: 14.0.0-rc.2
-  resolution: "@stellar/stellar-base@npm:14.0.0-rc.2"
+"@stellar/stellar-base@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@stellar/stellar-base@npm:14.0.0"
   dependencies:
-    "@noble/curves": ^1.9.2
+    "@noble/curves": ^1.9.6
     "@stellar/js-xdr": ^3.1.2
     base32.js: ^0.1.0
-    bignumber.js: ^9.3.0
+    bignumber.js: ^9.3.1
     buffer: ^6.0.3
-    sha.js: ^2.3.6
-  checksum: 212d34fd5f4cab060a6ffb3ddf78be5337457a53d61a3c5649fce7e9a05d97c57e6a82687cbacb20d66400c63b382a4d28a1a6980a9f6fb255d75b6644117bf3
+    sha.js: ^2.4.12
+  checksum: d51f8171dd0152946b96d94f1ef9a8476f69bd7c44781fdd15bfc99bd3d487a7c2c848ad4cd30e0c3f035c08e9841551d86e0743888cf218d88abd9faac2a26b
   languageName: node
   linkType: hard
 
-"@stellar/stellar-sdk@npm:14.0.0-rc.3":
-  version: 14.0.0-rc.3
-  resolution: "@stellar/stellar-sdk@npm:14.0.0-rc.3"
+"@stellar/stellar-sdk@npm:^14.1.0":
+  version: 14.1.0
+  resolution: "@stellar/stellar-sdk@npm:14.1.0"
   dependencies:
-    "@stellar/stellar-base": ^14.0.0-rc.2
+    "@stellar/stellar-base": ^14.0.0
     axios: ^1.8.4
     bignumber.js: ^9.3.1
     eventsource: ^2.0.2
@@ -2689,7 +2689,7 @@ __metadata:
     randombytes: ^2.1.0
     toml: ^3.0.0
     urijs: ^1.19.1
-  checksum: b323a2c6c2b25aa87783fe60f8da96467766e7d920653c428d302a50e731ff0903a14157323d377749e27bce3aa53150959d5762df8ae68b30f278c8d91c1f1f
+  checksum: 6670da631649c792cf42150d70fcb997babdaf9c88f240e3d59af9e5b726874bc0978ed09aed38c319cbaaf6672429194233d998f69e8edad5d78a097af3add8
   languageName: node
   linkType: hard
 
@@ -2697,7 +2697,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/common-stellar@workspace:packages/common-stellar"
   dependencies:
-    "@stellar/stellar-sdk": 14.0.0-rc.3
+    "@stellar/stellar-sdk": ^14.1.0
     "@subql/common": ^5.7.0
     "@subql/types-stellar": "workspace:*"
     "@types/js-yaml": ^4.0.4
@@ -2771,7 +2771,7 @@ __metadata:
     "@nestjs/schedule": ^5.0.1
     "@nestjs/schematics": ^11.0.2
     "@nestjs/testing": ^11.0.11
-    "@stellar/stellar-sdk": 14.0.0-rc.3
+    "@stellar/stellar-sdk": ^14.1.0
     "@subql/common": ^5.7.0
     "@subql/common-stellar": "workspace:*"
     "@subql/node-core": ^18.2.0
@@ -2832,7 +2832,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/types-stellar@workspace:packages/types"
   dependencies:
-    "@stellar/stellar-sdk": 14.0.0-rc.3
+    "@stellar/stellar-sdk": ^14.1.0
     "@subql/types-core": ^2.1.0
   languageName: unknown
   linkType: soft
@@ -4175,7 +4175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.3.0, bignumber.js@npm:^9.3.1":
+"bignumber.js@npm:^9.3.1":
   version: 9.3.1
   resolution: "bignumber.js@npm:9.3.1"
   checksum: 6ab100271a23a75bb8b99a4b1a34a1a94967ac0b9a52a198147607bd91064e72c6f356380d7a09cd687bf50d81ad2ed1a0a8edfaa90369c9003ed8bb2440d7f0
@@ -10541,7 +10541,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sha.js@npm:^2.3.6":
+"sha.js@npm:^2.4.12":
   version: 2.4.12
   resolution: "sha.js@npm:2.4.12"
   dependencies:


### PR DESCRIPTION
# Description
Updates the Stellar SDK to version 14 with protocol 23 support

And also fixes getting events cursors to use the current method from the deprecated pagingToken

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
